### PR TITLE
Fix the path to the go-provision binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ build:
 		CGO_ENABLED=0 \
 		GOOS=linux \
 		GOARCH=$(ARCH) go build \
-			-o $(BINDIR)/$$app github.com/zededa/go-provision/$$app; \
+			-o $(BINDIR)/$$app github.com/zededa/go-provision/$$app || exit 1; \
 	done
 
 clean:

--- a/scripts/device-steps.sh
+++ b/scripts/device-steps.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
-ETCDIR=/usr/local/etc/zededa
-BINDIR=/usr/local/bin/zededa
+ETCDIR=/opt/zededa/etc
+BINDIR=/opt/zededa/bin
 PROVDIR=$BINDIR
-LISPDIR=/usr/local/bin/lisp
+LISPDIR=/opt/zededa/lisp
+
+PATH=$BINDIR:$PATH
+
 WAIT=1
 EID_IN_DOMU=0
 while [ $# != 0 ]; do
@@ -226,44 +229,44 @@ mkdir -p /var/tmp/downloader/config/
 echo '{"MaxSpace":2000000}' >/var/tmp/downloader/config/global 
 
 echo "Starting downloader"
-/usr/local/bin/zededa/downloader >&/var/log/downloader.log&
+downloader >&/var/log/downloader.log&
 if [ $WAIT == 1 ]; then
     echo; read -n 1 -s -p "Press any key to continue"; echo; echo
 fi
 
 echo "Starting verifier"
-/usr/local/bin/zededa/verifier >&/var/log/verifier.log&
+verifier >&/var/log/verifier.log&
 if [ $WAIT == 1 ]; then
     echo; read -n 1 -s -p "Press any key to continue"; echo; echo
 fi
 
 echo "Starting eidregister"
-/usr/local/bin/zededa/eidregister >&/var/log/eidregister.log&
+eidregister >&/var/log/eidregister.log&
 if [ $WAIT == 1 ]; then
     echo; read -n 1 -s -p "Press any key to continue"; echo; echo
 fi
 
 echo "Starting identitymgr"
-/usr/local/bin/zededa/identitymgr >&/var/log/identitymgr.log&
+identitymgr >&/var/log/identitymgr.log&
 if [ $WAIT == 1 ]; then
     echo; read -n 1 -s -p "Press any key to continue"; echo; echo
 fi
 
 echo "Starting ZedRouter"
-/usr/local/bin/zededa/zedrouter >&/var/log/zedrouter.log&
+zedrouter >&/var/log/zedrouter.log&
 if [ $WAIT == 1 ]; then
     echo; read -n 1 -s -p "Press any key to continue"; echo; echo
 fi
 
 echo "Starting DomainMgr"
-/usr/local/bin/zededa/domainmgr >&/var/log/domainmgr.log&
+domainmgr >&/var/log/domainmgr.log&
 # Do something
 if [ $WAIT == 1 ]; then
     echo; read -n 1 -s -p "Press any key to continue"; echo; echo
 fi
 
 echo "Starting ZedManager"
-/usr/local/bin/zededa/zedmanager >&/var/log/zedmanager.log&
+zedmanager >&/var/log/zedmanager.log&
 # Do something
 if [ $WAIT == 1 ]; then
     echo; read -n 1 -s -p "Press any key to continue"; echo; echo
@@ -321,5 +324,3 @@ EOF
 $BINDIR/client $ETCDIR updateSwStatus
 
 echo "Initial setup done!"
-
-

--- a/src/github.com/zededa/go-provision/client/client.go
+++ b/src/github.com/zededa/go-provision/client/client.go
@@ -24,7 +24,7 @@ import (
 
 var maxDelay = time.Second * 600 // 10 minutes
 
-// Assumes the config files are in dirName, which is /usr/local/etc/zededa/
+// Assumes the config files are in dirName, which is /opt/zededa/etc
 // by default. The files are
 //  root-certificate.pem	Fixed? Written if redirected. factory-root-cert?
 //  server			Fixed? Written if redirected. factory-root-cert?
@@ -45,7 +45,7 @@ func main() {
 		log.Fatal("Usage: " + os.Args[0] +
 			"[<dirName> [<operations>...]]")
 	}
-	dirName := "/usr/local/etc/zededa/"
+	dirName := "/opt/zededa/etc"
 	if len(args) > 0 {
 		dirName = args[0]
 	}

--- a/src/github.com/zededa/go-provision/eidregister/eidregister.go
+++ b/src/github.com/zededa/go-provision/eidregister/eidregister.go
@@ -5,7 +5,7 @@
 // prov1.zededa.net which in turn registers them to the map servers
 // Reacts to the the collection of EIDStatus structs in
 // /var/run/identitymgr/status/*.json, and invokes /rest/eid-register
-// Reads config from arg1 or /usr/local/etc/zededa/
+// Reads config from arg1 or /opt/zededa/etc
 
 package main
 
@@ -37,7 +37,7 @@ func main() {
 	log.Printf("Starting eidregister\n")
 
 	args := os.Args[1:]
-	dirName := "/usr/local/etc/zededa/"
+	dirName := "/opt/zededa/etc"
 	if len(args) > 0 {
 		dirName = args[0]
 	}

--- a/src/github.com/zededa/go-provision/server/server.go
+++ b/src/github.com/zededa/go-provision/server/server.go
@@ -38,7 +38,7 @@ type ServerCertInfo struct {
 }
 
 // Assumes the config files are in dirName, which is
-// is /usr/local/etc/zededa-server/ by default. The files are
+// is /opt/zededa/etc/zededa-server/ by default. The files are
 //  intermediate-server.cert.pem  server cert plus intermediate CA cert
 //  server.key.pem
 //  zedserverconfig.json	ZedServerConfig sent to devices
@@ -51,7 +51,7 @@ func main() {
 	if len(args) > 1 {
 		log.Fatal("Usage: " + os.Args[0] + "[<dirName>]")
 	}
-	dirName := "/usr/local/etc/zededa-server/"
+	dirName := "/opt/zededa/etc/zededa-server/"
 	if len(args) > 0 {
 		dirName = args[0]
 	}

--- a/src/github.com/zededa/go-provision/zedrouter/lisp.go
+++ b/src/github.com/zededa/go-provision/zedrouter/lisp.go
@@ -119,10 +119,10 @@ lisp interface {
 }
 `
 
-const baseFilename = "/usr/local/etc/zededa/lisp.config.base"
-const destFilename = "/usr/local/bin/lisp/lisp.config"
-const RestartCmd =  "/usr/local/bin/lisp/RESTART-LISP"
-const StopCmd =  "/usr/local/bin/lisp/STOP-LISP"
+const baseFilename = "/opt/zededa/etc/lisp.config.base"
+const destFilename = "/opt/zededa/bin/lisp/lisp.config"
+const RestartCmd = "/opt/zededa/bin/lisp/RESTART-LISP"
+const StopCmd = "/opt/zededa/bin/lisp/STOP-LISP"
 
 // We write files with the IID-specifics (and not EID) to files
 // in <globalRunDirname>/lisp/<iid>.


### PR DESCRIPTION
The go-provision binaries were called from /usr/local. After they have
been moved to /opt/zededa, the code needs to be updated to call them
from /opt/zededa.

Also fix the Makefile to exit if we encounter a build failure.