### PR TITLE
Add LinuxKit build.yml

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -1,0 +1,18 @@
+# LinuxKit package build.
+#
+# Build with:
+# $ linuxkit pkg build -disable-content-trust -hash latest -force .
+#
+# Push to Docker Hub with:
+#
+# $ linuxkit pkg push -hash latest -force -disable-content-trust .
+#
+# Ideally the hash and force will be removed but they'll require
+# changes to linuxkit or the go-provision source build.
+#
+# "--disable-content-trust" also has to go, once we set up signing
+# of packages in zededa docker hub.
+
+org: zededa
+image: ztools
+network: yes


### PR DESCRIPTION
This change adds support for building with linuxkit.

This is trickier than zenbuild because go-provision has the source base path not in a subdirectory, while linuxkit pkglib uses "git ls-tree" of the source base path to find the hash for the build.
This in turn forces us to use "latest" as the fixed tag, which in turn forces us to force the build.