### PR TITLE
Fix bug where a failed boot of a domU/appInstance didn't go away when…

### DIFF
--- a/cmd/zedmanager/updatestatus.go
+++ b/cmd/zedmanager/updatestatus.go
@@ -215,12 +215,12 @@ func doUpdate(uuidStr string, config types.AppInstanceConfig,
 
 	// The existence of Config is interpreted to mean the
 	// AI should be INSTALLED. Activate is checked separately.
-	changed, proceed := doInstall(uuidStr, config, status)
-	if !proceed {
+	changed, done := doInstall(uuidStr, config, status)
+	if !done {
 		return changed
 	}
 	if !config.Activate {
-		if status.Activated {
+		if status.Activated || status.ActivateInprogress {
 			changed = doInactivate(uuidStr, status)
 		} else {
 			// If we have a !ReadOnly disk this will create a copy
@@ -474,6 +474,9 @@ func doActivate(uuidStr string, config types.AppInstanceConfig,
 	log.Printf("doActivate for %s\n", uuidStr)
 	changed := false
 
+	// Track that we have cleanup work in case something fails
+	status.ActivateInprogress = true
+
 	// Make sure we have an AppNetworkConfig
 	MaybeAddAppNetworkConfig(config, status)
 
@@ -544,6 +547,7 @@ func doActivate(uuidStr string, config types.AppInstanceConfig,
 
 	if !status.Activated {
 		status.Activated = true
+		status.ActivateInprogress = false
 		changed = true
 	}
 	log.Printf("doActivate done for %s\n", uuidStr)
@@ -555,7 +559,7 @@ func doRemove(uuidStr string, status *types.AppInstanceStatus) (bool, bool) {
 
 	changed := false
 	del := false
-	if status.Activated {
+	if status.Activated || status.ActivateInprogress {
 		changed = doInactivate(uuidStr, status)
 	}
 	if !status.Activated {
@@ -603,6 +607,7 @@ func doInactivate(uuidStr string, status *types.AppInstanceStatus) bool {
 	log.Printf("Done with AppNetworkStatus removal for %s\n", uuidStr)
 
 	status.Activated = false
+	status.ActivateInprogress = false
 	log.Printf("doInactivate done for %s\n", uuidStr)
 	return changed
 }

--- a/types/zedmanagertypes.go
+++ b/types/zedmanagertypes.go
@@ -65,11 +65,12 @@ func (config AppInstanceConfig) VerifyFilename(fileName string) bool {
 
 // Indexed by UUIDandVersion as above
 type AppInstanceStatus struct {
-	UUIDandVersion    UUIDandVersion
-	DisplayName       string
-	Activated         bool
-	StorageStatusList []StorageStatus
-	EIDList           []EIDStatusDetails
+	UUIDandVersion     UUIDandVersion
+	DisplayName        string
+	Activated          bool
+	ActivateInprogress bool // Needed for cleanup after failure
+	StorageStatusList  []StorageStatus
+	EIDList            []EIDStatusDetails
 	// Mininum state across all steps and all StorageStatus.
 	// INITIAL implies error.
 	State SwState


### PR DESCRIPTION
… the AppInstanceConfig was deleted

The cleanup was triggered by AppInstanceStatus being marked as Activated, but when that fails it never gets marked. Hence adding a ActivateInprogress means we can track that we have zedrouter and/or domainmgr to clean up.