### PR TITLE
Use (and verify) our UUID instead of accepting the first we receive from zedcloud

### DIFF
--- a/cmd/zedagent/handleconfig.go
+++ b/cmd/zedagent/handleconfig.go
@@ -33,11 +33,6 @@ var configApi string = "api/v1/edgedevice/config"
 var statusApi string = "api/v1/edgedevice/info"
 var metricsApi string = "api/v1/edgedevice/metrics"
 
-// XXX remove global variables
-// XXX shouldn't we know our own device UUID? Get from some global struct?
-// Or read from uuid file?
-var deviceId string
-
 // These URLs are effectively constants; depends on the server name
 var configUrl string
 var metricsUrl string
@@ -271,15 +266,16 @@ func inhaleDeviceConfig(config *zconfig.EdgeDevConfig) {
 	var devId = &zconfig.UUIDandVersion{}
 
 	devId = config.GetId()
-	if devId != nil {
-		// store the device id
-		deviceId = devId.Uuid
-		if devId.Version == activeVersion {
-			log.Printf("Same version, skipping:%v\n", config.Id.Version)
-			return
-		}
-		activeVersion = devId.Version
+	if deviceUUID.String() != devId.Uuid {
+		log.Printf("Config to for us: %s, got %s\n",
+			deviceUUID.String(), devId.Uuid)
+		return
 	}
+	if devId.Version == activeVersion {
+		log.Printf("Same version, skipping:%v\n", config.Id.Version)
+		return
+	}
+	activeVersion = devId.Version
 	handleLookUpParam(config)
 
 	// delete old app configs, if any

--- a/cmd/zedagent/handlemetrics.go
+++ b/cmd/zedagent/handlemetrics.go
@@ -271,7 +271,7 @@ func PublishMetricsToZedCloud(cpuStorageStat [][]string, iteration int) {
 	ReportDeviceMetric.Memory = new(zmet.MemoryMetric)
 	ReportDeviceMetric.Compute = new(zmet.DevCpuMetric)
 
-	ReportMetrics.DevID = *proto.String(deviceId)
+	ReportMetrics.DevID = *proto.String(deviceUUID.String())
 	ReportZmetric := new(zmet.ZmetricTypes)
 	*ReportZmetric = zmet.ZmetricTypes_ZmDevice
 
@@ -531,7 +531,7 @@ func PublishDeviceInfoToZedCloud(baseOsStatus map[string]types.BaseOsStatus,
 	deviceType := new(zmet.ZInfoTypes)
 	*deviceType = zmet.ZInfoTypes_ZiDevice
 	ReportInfo.Ztype = *deviceType
-	ReportInfo.DevId = *proto.String(deviceId)
+	ReportInfo.DevId = *proto.String(deviceUUID.String())
 
 	ReportDeviceInfo := new(zmet.ZInfoDevice)
 
@@ -765,7 +765,7 @@ func PublishAppInfoToZedCloud(uuid string, aiStatus *types.AppInstanceStatus,
 	appType := new(zmet.ZInfoTypes)
 	*appType = zmet.ZInfoTypes_ZiApp
 	ReportInfo.Ztype = *appType
-	ReportInfo.DevId = *proto.String(deviceId)
+	ReportInfo.DevId = *proto.String(deviceUUID.String())
 
 	ReportAppInfo := new(zmet.ZInfoApp)
 

--- a/cmd/zedagent/zedagent.go
+++ b/cmd/zedagent/zedagent.go
@@ -36,12 +36,15 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/satori/go.uuid"
 	"github.com/zededa/go-provision/assignableadapters"
 	"github.com/zededa/go-provision/hardware"
 	"github.com/zededa/go-provision/types"
 	"github.com/zededa/go-provision/watch"
+	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 )
 
 // Keeping status in /var/run to be clean after a crash/reboot
@@ -99,7 +102,9 @@ const (
 // Set from Makefile
 var Version = "No version specified"
 
+// XXX remove global variables
 var deviceNetworkStatus types.DeviceNetworkStatus
+var deviceUUID uuid.UUID
 
 // Dummy used when we don't have anything to pass
 type dummyContext struct {
@@ -349,6 +354,20 @@ func handleVerifierRestarted(ctxArg interface{}, done bool) {
 }
 
 func handleInit() {
+	// Determine our UUID
+	if _, err := os.Stat(uuidFileName); err != nil {
+		log.Fatalf("We don't have a UUID %s\n", err)
+	}
+	b, err := ioutil.ReadFile(uuidFileName)
+	if err != nil {
+		log.Fatal("ReadFile", err, uuidFileName)
+	}
+	uuidStr := strings.TrimSpace(string(b))
+	deviceUUID, err = uuid.FromString(uuidStr)
+	if err != nil {
+		log.Fatal("uuid.FromString", err, string(b))
+	}
+	fmt.Printf("Read UUID %s\n", deviceUUID)
 
 	initializeDirs()
 	initMaps()


### PR DESCRIPTION
NOTE: This assumes that zedcloud uses the UUID which the device produces during onboarding, but I currently don't see how that is passed to zedcloud.

If we want the flow to be in the reverse direction (zedcloud generating and providing the uuid), then we need that from the lookupParam API call (and we need to use it to set the hostname for LISP nat traversal). 