### PR TITLE
reduce logging from logging

### DIFF
--- a/scripts/device-steps.sh
+++ b/scripts/device-steps.sh
@@ -285,7 +285,7 @@ if [ ! -d $LOGDIRB ]; then
 fi
 
 echo "Set up log capture"
-DOM0LOGFILES="dhcpcd.err.log ntpd.err.log wlan.err.log wwan.err.log zededa-tools.err.log dhcpcd.out.log ntpd.out.log wlan.out.log wwan.out.log zededa-tools.out.log"
+DOM0LOGFILES="dhcpcd.err.log ntpd.err.log wlan.err.log wwan.err.log dhcpcd.out.log ntpd.out.log wlan.out.log wwan.out.log"
 # XXX note that these tail and dmesg processes are not killed when
 # device-steps.sh is re-run
 for f in $DOM0LOGFILES; do


### PR DESCRIPTION
logmanager produces output which can go to zededa-tools.out.log. Remove that and its err file from what we log.
