### PR TITLE
changing zededa dataplane name from dataplane to lisp-ztr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ COPY --from=build /var/tmp/zededa/lisp.config.base /var/tmp/zededa/lisp.config.b
 # the default /config (since that is expected to be an empty mount point)
 COPY --from=build /config /opt/zededa/examples/config
 COPY --from=build /go/bin/* /opt/zededa/bin/
-COPY --from=lisp /lisp/dataplane /opt/zededa/bin/
+COPY --from=lisp /lisp/lisp-ztr /opt/zededa/bin/
 COPY --from=lisp /lisp /opt/zededa/lisp/
 COPY --from=lisp /usr/bin/pydoc /usr/bin/smtpd.py /usr/bin/python* /usr/bin/
 COPY --from=lisp /usr/lib/libpython* /usr/lib/libffi.so* /usr/lib/

--- a/cmd/zedrouter/lisp.go
+++ b/cmd/zedrouter/lisp.go
@@ -540,7 +540,7 @@ func restartLisp(upLinkStatus []types.NetworkUplink, devices string) {
 
 func maybeStartLispDataPlane() {
 	if debug {
-		log.Printf("maybeStartLispDataPlane: %s\n", "/opt/zededa/bin/dataplane")
+		log.Printf("maybeStartLispDataPlane: %s\n", "/opt/zededa/bin/lisp-ztr")
 	}
 	isRunning, _ := isLispDataPlaneRunning()
 	if isRunning {
@@ -549,12 +549,12 @@ func maybeStartLispDataPlane() {
 	// Dataplane is currently running. Start it.
 	cmd := "nohup"
 	args := []string{
-		"/opt/zededa/bin/dataplane",
+		"/opt/zededa/bin/lisp-ztr",
 	}
 	go wrap.Command(cmd, args...).Output()
 }
 
-// Stop if dataplane is running
+// Stop if dataplane(lisp-ztr) is running
 // return true if dataplane was running and we stopped it.
 // false otherwise
 func maybeStopLispDataPlane() bool {
@@ -592,7 +592,7 @@ func isLispDataPlaneRunning() (bool, []string) {
 	log.Printf("isLispDataPlaneRunning: Instances of %s is running.\n", prog)
 	pids := strings.Split(string(out), "\n")
 
-	// The last entry returns by strings.Split is empty string.
+	// The last entry returned by strings.Split is an empty string.
 	// splice the last entry out.
 	pids = pids[:len(pids)-1]
 

--- a/cmd/zedrouter/zedrouter.go
+++ b/cmd/zedrouter/zedrouter.go
@@ -42,7 +42,7 @@ const (
 	tmpDirname    = "/var/tmp/zededa"
 	DNCDirname    = tmpDirname + "/DeviceNetworkConfig"
 	DNSDirname    = runDirname + "/DeviceNetworkStatus"
-	DataPlaneName = "dataplane"
+	DataPlaneName = "lisp-ztr"
 )
 
 // Set from Makefile


### PR DESCRIPTION
Zededa dataplane has been renamed to lisp-ztr in lisp docker.

https://github.com/zededa/lisp/pull/7

This is the pull request that has the name change.

go-provision pulls zededa dataplane binary from lispdocker image. After the above mentioned pull request is accepted, this code should go into go-provision to avoid build break.