### PR TITLE
Add -p <file> to parse and print a protobuf checkpoint file

### DIFF
--- a/cmd/zedagent/handleconfig.go
+++ b/cmd/zedagent/handleconfig.go
@@ -362,7 +362,7 @@ func writeProtoMessage(filename string, contents []byte) {
 func readSavedProtoMessage(filename string, force bool) (*zconfig.EdgeDevConfig, error) {
 	info, err := os.Stat(filename)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if os.IsNotExist(err) && !force {
 			return nil, nil
 		} else {
 			return nil, err


### PR DESCRIPTION
Add -V to validate the strings in protobuf as UTF-8

Example use /opt/zededa/bin/zedagent -p /persist/checkpoint/lastconfig
