### PR TITLE
Add map-cache with IPv4 prefix in lisp.config

### DIFF
--- a/cmd/zedrouter/lisp.go
+++ b/cmd/zedrouter/lisp.go
@@ -57,7 +57,7 @@ const lispIPv4IIDtemplate = `
 lisp map-cache {
     prefix {
         instance-id = %d
-        eid-prefix = %s/8
+        eid-prefix = %s
         send-map-request = yes
     }
 }
@@ -320,17 +320,6 @@ func createLispEidConfiglet(lispRunDirname string,
 			}
 			one := fmt.Sprintf("    rloc {\n        address = %s\n        priority = %d\n    }\n", i.Addr, prio)
 			rlocString += one
-		}
-	}
-	if  AppIPAddr != nil && !EID.Equal(AppIPAddr) {
-		cfgPathnameIID := lispRunDirname + "/" +
-		strconv.FormatUint(uint64(IID), 10)
-		file1, err := os.OpenFile(cfgPathnameIID, os.O_APPEND | os.O_WRONLY, 0600)
-		if err == nil {
-			ipv4Mask := net.CIDRMask(8, 32)
-			ipv4Network := AppIPAddr.Mask(ipv4Mask)
-			file1.WriteString(fmt.Sprintf(lispIPv4IIDtemplate, IID, ipv4Network.String()))
-			file1.Close()
 		}
 	}
 	// Append to rlocString based on AppIPAddr


### PR DESCRIPTION
We missed adding map-cache configuration for IPv4 EID prefix. Without this lispers.net would not send map-cache resolution request to map-server.