### PR TITLE
Enable PAC file parsing. Parse system adapters when networks change.

### DIFF
--- a/zedcloud/lookupproxy.go
+++ b/zedcloud/lookupproxy.go
@@ -4,12 +4,14 @@
 package zedcloud
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/zededa/go-provision/types"
-	//"github.com/zededa/go-provision/zedpac"
+	"github.com/zededa/go-provision/zedpac"
 	"net/url"
+	"strings"
 )
 
 func LookupProxy(
@@ -34,7 +36,6 @@ func LookupProxy(
 			return nil, errors.New(errStr)
 		}
 
-		/*
 		// Check if we have a PAC file
 		if len(proxyConfig.Pacfile) > 0 {
 			pacFile, err := base64.StdEncoding.DecodeString(proxyConfig.Pacfile)
@@ -82,7 +83,6 @@ func LookupProxy(
 			log.Debugf("LookupProxy: PAC proxy being used is %s", proxy0)
 			return proxy, err
 		}
-		*/
 
 		config := &Config{}
 		for _, proxy := range proxyConfig.Proxies {


### PR DESCRIPTION
We might have some system adapters pointing to network with proxy configuration initially. These networks might change. We should parse the system adapters and update DeviceUplinkConfig when these network changes.

At this point we do not check if a particular network (with proxies) has changed and only then re-parse system adapters. When there is a change in network and there is at least one network with proxy configuration we re-parse all system adapters.