### PR TITLE
Rudimentary cross compiling capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,13 @@ FROM golang:1.9.1-alpine AS build
 RUN apk update
 RUN apk add --no-cache git gcc linux-headers libc-dev util-linux
 
+# These three are supporting rudimentary cross-build capabilities.
+# The only one supported so far is cross compiling for aarch64 on x86
+ENV CGO_ENABLED=1
+ARG GOARCH=
+ARG CROSS_GCC=https://musl.cc/aarch64-linux-musleabi-cross.tgz
+RUN [ -z "$GOARCH" ] || (cd / ; apk add --no-cache wget && wget -O - $CROSS_GCC | tar xzvf -)
+
 ADD ./  /go/src/github.com/zededa/go-provision/
 ADD etc /config
 ADD scripts/device-steps.sh \
@@ -21,9 +28,15 @@ RUN cp /opt/zededa/bin/versioninfo /opt/zededa/bin/versioninfo.1
 # Echo for builders enjoyment
 RUN echo Building: `cat /opt/zededa/bin/versioninfo`
 
-RUN go install github.com/zededa/go-provision/zedbox/...
-RUN cd /opt/zededa/bin ; ln -s /go/bin/* .
-RUN cd /opt/zededa/bin ; ln -s zedbox client; ln -s zedbox domainmgr; ln -s zedbox downloader; ln -s zedbox hardwaremodel; ln -s zedbox identitymgr; ln -s zedbox ledmanager; ln -s zedbox logmanager; ln -s zedbox verifier; ln -s zedbox zedagent; ln -s zedbox zedmanager; ln -s zedbox zedrouter; ln -s zedbox ipcmonitor; ln -s zedbox nim; ln -s zedbox waitforaddr; ln -s zedbox diag;ln -s zedbox baseosmgr;ln -s zedbox wstunnelclient
+RUN [ -z "$GOARCH" ] || export CC=$(echo /*-cross/bin/*-gcc)           ;\
+    go install github.com/zededa/go-provision/zedbox/...               ;\
+    if [ -f /go/bin/*/zedbox ] ; then mv /go/bin/*/zedbox /go/bin ; fi
+RUN ln -s /go/bin/zedbox /opt/zededa/bin/zedbox ;\
+    for app in   \
+      client domainmgr downloader hardwaremodel identitymgr ledmanager \
+      logmanager verifier zedagent zedmanager zedrouter ipcmonitor nim \
+      waitforaddr diag baseosmgr wstunnelclient ;\
+    do ln -s zedbox /opt/zededa/bin/$app ; done
 
 # Second stage of the build is creating a minimalistic container
 FROM scratch

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ BUILD_VERSION=$(shell scripts/getversion.sh)
 OBJDIR      := $(PWD)/bin/$(ARCH)
 BINDIR	    := $(OBJDIR)
 
+DOCKER_ARGS=$${GOARCH:+--build-arg GOARCH=}$(GOARCH)
+DOCKER_TAG=zededa/ztools:local$${GOARCH:+-}$(GOARCH)
+
 APPS = zedbox
 APPS1 = logmanager ledmanager downloader verifier client zedrouter domainmgr identitymgr zedmanager zedagent hardwaremodel ipcmonitor nim diag baseosmgr wstunnelclient
 
@@ -61,10 +64,10 @@ build:
 	done
 
 build-docker:
-	docker build -t zededa/ztools:local .
+	docker build $(DOCKER_ARGS) -t $(DOCKER_TAG) .
 
 build-docker-git:
-	git archive HEAD | docker build -t zededa/ztools:local -
+	git archive HEAD | docker build $(DOCKER_ARGS) -t $(DOCKER_TAG) -
 
 Gopkg.lock: Gopkg.toml
 	mkdir -p .go/src/github.com/zededa && ln -s ../../../.. .go/src/github.com/zededa/go-provision || :


### PR DESCRIPTION
This small change allows for the following:
   $ make GOARCH=arm64 build-docker
and the resulting container will be zededa/ztools:local-arm64

Nothing default changes. The cross logic (including the tag on the container) only gets triggered when GOARCH is set to arm64

For now, only arm64 is supported, but an astute reader will recognize that something like this is now [almost] possible (although completely useless ;-)):
   $ make GOARCH=s390x CROSS_GCC=https://musl.cc/s390x-linux-musl-cross.tgz build-docker