### PR TITLE
Emergency ability to create a GlobalConfig in the build in /config/

### DIFF
--- a/docs/build-config-files
+++ b/docs/build-config-files
@@ -1,0 +1,17 @@
+It is possible to provide an initial DevicePortConfig and/or GlobalConfig
+during the build.
+
+The former can be used to specify proxies and static IP configuration for
+the ports, if that is necessary to have the device connect to zedcloud.
+But a DevicePortConfig can also be added to a USB stick in which case it
+will be copied from the USB stick on boot. See mkusb.sh
+
+The latter can be used to specify the initial timers and ssh/usb behavior
+which will be in place until the device connects to zedcloud and gets its
+configuration from there.
+
+To add either during the build, in zenbuild's conf directory create a
+subdirectory called DevicePortConfig or GlobalConfig, respectively.
+Then add the valid json file named as global.json in that directory.
+
+make conf.img; make installer.raw

--- a/scripts/device-steps.sh
+++ b/scripts/device-steps.sh
@@ -9,6 +9,7 @@ BINDIR=/opt/zededa/bin
 TMPDIR=/var/tmp/zededa
 DNCDIR=$TMPDIR/DeviceNetworkConfig
 DPCDIR=$TMPDIR/DevicePortConfig
+GCDIR=$PERSISTDIR/config/GlobalConfig
 LISPDIR=/opt/zededa/lisp
 LOGDIRA=$PERSISTDIR/IMGA/log
 LOGDIRB=$PERSISTDIR/IMGB/log
@@ -92,7 +93,7 @@ if [ $? = 0 ]; then
     killall dmesg
 fi
 
-DIRS="$CONFIGDIR $PERSISTDIR $TMPDIR $CONFIGDIR/DevicePortConfig $TMPDIR/DeviceNetworkConfig/ $TMPDIR/AssignableAdapters"
+DIRS="$CONFIGDIR $PERSISTDIR $TMPDIR $CONFIGDIR/DevicePortConfig $CONFIGDIR/GlobalConfig $TMPDIR/DeviceNetworkConfig/ $TMPDIR/AssignableAdapters"
 
 for d in $DIRS; do
     d1=`dirname $d`
@@ -199,13 +200,23 @@ ls -lt $PERSISTDIR/downloads/*/*
 echo
 
 # Places for surviving global config and status
-if [ ! -d $PERSISTDIR/config/GlobalConfig ]; then
-    mkdir -p $PERSISTDIR/config/GlobalConfig
+if [ ! -d $GCDIR ]; then
+    mkdir -p $GCDIR
 fi
-if [ -f $PERSISTDIR/config/GlobalConfig ]; then
+if [ -f /var/tmp/zededa/GlobalConfig ]; then
     rm -f /var/tmp/zededa/GlobalConfig
 fi
-ln -s $PERSISTDIR/config/GlobalConfig /var/tmp/zededa/GlobalConfig
+ln -s $GCDIR /var/tmp/zededa/GlobalConfig
+
+# Copy any GlobalConfig
+dir=$CONFIGDIR/GlobalConfig
+for f in $dir/*.json; do
+    if [ "$f" = "$dir/*.json" ]; then
+	break
+    fi
+    echo "Copying from $f to $GCDIR"
+    cp -p $f $GCDIR
+done
 
 if [ ! -d $PERSISTDIR/status ]; then
     mkdir -p $PERSISTDIR/status
@@ -311,7 +322,7 @@ for f in $dir/*.json; do
     if [ "$f" = "$dir/*.json" ]; then
 	break
     fi
-    echo "Copying from $f"
+    echo "Copying from $f to $DPCDIR"
     cp -p $f $DPCDIR
 done
 


### PR DESCRIPTION
Will be used as the initial GlobalConfig until zedcloud sends us a config.

Note that Kalyan's issue had nothing to do with that; he had configured an app instance which referred to an image which does not exist in alpha, and there is no error check at config time. Result is that device did not receive any updated config from zedcloud. Error could be found in zadmin only.

But this capability might be useful for onboarding new hardware when we want to control the settings from boot.