### PR TITLE
First-cut assignable-adapters config for the iEi SER0 device (Intel Tank)

### DIFF
--- a/AssignableAdapters/iEi.SER0.json
+++ b/AssignableAdapters/iEi.SER0.json
@@ -1,0 +1,5 @@
+{ "IoBundleList": [
+    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
+    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
+    { "Type": 255, "Name": "FPGA", "Members": [ "FPGA" ], "PciLong": "0000:01:00.0", "PciShort":"01:00.0" }
+] }

--- a/DeviceNetworkConfig/iEi.SER0.json
+++ b/DeviceNetworkConfig/iEi.SER0.json
@@ -1,0 +1,4 @@
+{
+    "Uplink":["eth0","wlan0","wwan0"],
+    "FreeUplinks":["eth0","wlan0"]
+}


### PR DESCRIPTION
- Add the assignable-adapters for iEi Tank device.
- dmidecode output:

System Information
	Manufacturer: iEi
	Product Name: SER0
	Version: V1.0
	Serial Number: SC18726477
	UUID: BE59D77C-5BB2-11D9-B3A1-2160825B1600
	Wake-up Type: Power Switch
	SKU Number: Default string
	Family: Default string