### PR TITLE
dockerized direct command-line build, plus cleaner makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 obj
+dist/

--- a/README.md
+++ b/README.md
@@ -26,4 +26,17 @@ In addition there are debugging tools like
  - ipcmonitor - subscribes to the agents/collections passed between the different microservices
 
 In order to conserve filesystem space, all of the agents above are built into a single executable (zedbox) and are differentiated based on the symbolic link (very similar to how BusyBox does it with traditional UNIX utilities). 
- 
+
+## Building
+
+Generally, the build is done inside a Docker container to ensure environment consistency. This container is `FROM golang:${GOVER}-alpine`. When running via docker-for-mac or docker-for-windows, you can run in a container that is derived from the library `golang` image. However, when building on Linux, the output artifacts will have the wrong ownership. Thus, we build a simple special image that contains and writes to the correct user.
+
+All output binaries and links are in `dist/`.
+
+Make targets of note:
+
+* `make build`: build go-provision containerized
+* `make build BUILD=local`: build go-provision via your local golang installation
+* `make builder-image`: build the builder image for your user
+* `make shell`: launch a shell inside the builder image, whence you can run all commands. It also sets `BUILD=local`, so that you can run just `make build` inside.
+

--- a/dev-support/Dockerfile
+++ b/dev-support/Dockerfile
@@ -1,0 +1,12 @@
+ARG GOVER=1.9.1
+FROM golang:${GOVER}-alpine
+ARG USER
+ARG GROUP
+ARG UID
+ARG GID
+RUN apk add --no-cache openssh-client git gcc linux-headers libc-dev util-linux libpcap-dev bash vim make
+RUN deluser ${USER} ; delgroup ${GROUP} || :
+RUN sed -ie /:${UID}:/d /etc/passwd /etc/shadow ; sed -ie /:${GID}:/d /etc/group || :
+RUN addgroup -g ${GID} ${GROUP} && adduser -h /home/${USER} -G ${GROUP} -D -H -u ${UID} ${USER}
+ENV HOME /home/${USER}
+


### PR DESCRIPTION
This brings a number of changes to the `Makefile`. As requested [here](https://github.com/zededa/go-provision/pull/348#issuecomment-483865666):

1. Keeps `make shell` in place (which launches a shell inside a docker container), but also runs the build directly inside a docker container, via `make build`
2. Adds an option to build locally using `make build BUILD=local`. 
3. You also can do just the build via `make zedbox` and `make zedbox BUILD=local`
4. When you run `make shell`, it sets `BUILD=local`, so in that shell you can just do `make build` or `make zedbox` and it does the right thing.
5. Cleans up the various makefile targets to eliminate some loops and make it easier to manage dependencies, as well as easier to read.
6. Moves the "builder image" into its own named target `builder-image`, creates a `Dockerfile` for it and moves it into its own directory.
7. Moves the outputs to `dist/`, keeping it consistent with zenbuild (and many other open projects), and adds it too `.gitignore`
8. Updates the README to reflect the changes.

One point of note: the `Dockerfile` in the root directory here looks like it also does a lot of the building that we do in the `Makefile`. Is that redundant? 