### PR TITLE
Fix to enable portmap when multiple management interfaces

### DIFF
--- a/cmd/zedrouter/acl.go
+++ b/cmd/zedrouter/acl.go
@@ -554,7 +554,7 @@ func aceToRules(bridgeName string, vifName string, ace types.ACE, ipVer int, bri
 			// These rules should only apply on the uplink
 			// interfaces but for now we just compare the protocol
 			// and port number.
-			// The DNAT/SNAT rules do not compare fport and ipset
+			// The DNAT/MASQURADE rules do not compare fport and ipset
 			rule1 := []string{"PREROUTING",
 				"-p", protocol, "--dport", lport,
 				"-j", "DNAT", "--to-destination", target}
@@ -562,8 +562,8 @@ func aceToRules(bridgeName string, vifName string, ace types.ACE, ipVer int, bri
 			// e.g., out a directly attached interface in the domU
 			rule2 := []string{"POSTROUTING",
 				"-p", protocol, "-o", bridgeName,
-				"--dport", targetPort, "-j", "SNAT",
-				"--to-source", bridgeIP}
+				"-d", appIP,
+				"--dport", targetPort, "-j", "MASQUERADE"}
 			// Below we make sure the mapped packets get through
 			// Note that port/targetport change relative
 			// no normal ACL above.

--- a/cmd/zedrouter/acl.go
+++ b/cmd/zedrouter/acl.go
@@ -554,7 +554,7 @@ func aceToRules(bridgeName string, vifName string, ace types.ACE, ipVer int, bri
 			// These rules should only apply on the uplink
 			// interfaces but for now we just compare the protocol
 			// and port number.
-			// The DNAT/MASQURADE rules do not compare fport and ipset
+			// The DNAT/SNAT rules do not compare fport and ipset
 			rule1 := []string{"PREROUTING",
 				"-p", protocol, "--dport", lport,
 				"-j", "DNAT", "--to-destination", target}
@@ -562,8 +562,8 @@ func aceToRules(bridgeName string, vifName string, ace types.ACE, ipVer int, bri
 			// e.g., out a directly attached interface in the domU
 			rule2 := []string{"POSTROUTING",
 				"-p", protocol, "-o", bridgeName,
-				"-d", appIP,
-				"--dport", targetPort, "-j", "MASQUERADE"}
+				"--dport", targetPort, "-j", "SNAT",
+				"--to-source", bridgeIP}
 			// Below we make sure the mapped packets get through
 			// Note that port/targetport change relative
 			// no normal ACL above.

--- a/cmd/zedrouter/zedrouter.go
+++ b/cmd/zedrouter/zedrouter.go
@@ -550,6 +550,23 @@ func handleInit(runDirname string) {
 	if err != nil {
 		log.Fatal("Failed setting net.bridge-nf-call-arptables ", err)
 	}
+	// Needed in test setups where we have the same subnet on multiple ports
+	// XXX restrict to management ports?
+	_, err = wrap.Command("sysctl", "-w",
+		"net.ipv4.conf.all.rp_filter=2").Output()
+	if err != nil {
+		log.Fatal("Failed setting rp_filter ", err)
+	}
+	_, err = wrap.Command("sysctl", "-w",
+		"net.ipv4.conf.all.log_martians=1").Output()
+	if err != nil {
+		log.Fatal("Failed setting log_martians ", err)
+	}
+	_, err = wrap.Command("sysctl", "-w",
+		"net.ipv4.conf.default.log_martians=1").Output()
+	if err != nil {
+		log.Fatal("Failed setting log_martians ", err)
+	}
 
 	// XXX hack to determine whether a real system or Erik's laptop
 	_, err = wrap.Command("xl", "list").Output()

--- a/cmd/zedrouter/zedrouter.go
+++ b/cmd/zedrouter/zedrouter.go
@@ -2427,6 +2427,9 @@ func doAppNetworkConfigModify(ctx *zedrouterContext, key string,
 	}
 
 	if config.Activate && !status.Activated {
+		// XXX the doAppNetworkModify calls above did
+		// an updateACL and doActivate will do a createACL resulting
+		// in duplicate (but harmless) rules.
 		doActivate(ctx, config, status)
 	}
 


### PR DESCRIPTION
In our lab setup having multiple management ports resulted in ssh portmap failing,
That's due to the environment with multiple ports on the same IP subnet, triggering the overconstraining reverse-path filter logic in the Linux kernel.
Disabling that.