### PR TITLE
Watchdog the device if the goroutine doing a get of config or a post …

### DIFF
--- a/cmd/zedagent/zedagent.go
+++ b/cmd/zedagent/zedagent.go
@@ -212,6 +212,8 @@ func Run() {
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(25 * time.Second)
 	agentlog.StillRunning(agentName)
+	agentlog.StillRunning(agentName + "config")
+	agentlog.StillRunning(agentName + "metrics")
 
 	// Tell ourselves to go ahead
 	// initialize the module specifig stuff

--- a/scripts/device-steps.sh
+++ b/scripts/device-steps.sh
@@ -101,11 +101,15 @@ for AGENT in $AGENTS; do
 	continue
     fi
     echo "file = /var/run/$AGENT.touch" >>$TMPDIR/watchdogall.conf
-    if [ "$AGENT" = "zedagent" ]; then
-	echo "file = /var/run/${AGENT}config.touch" >>$TMPDIR/watchdogall.conf
-	echo "file = /var/run/${AGENT}metrics.touch" >>$TMPDIR/watchdogall.conf
-    fi
     echo "change = 300" >>$TMPDIR/watchdogall.conf
+    if [ "$AGENT" = "zedagent" ]; then
+	cat >>$TMPDIR/watchdogall.conf <<EOF
+file = /var/run/${AGENT}config.touch
+change = 300
+file = /var/run/${AGENT}metrics.touch
+change = 300
+EOF
+    fi
 done
 
 # In case watchdog is running we restart it with the base file

--- a/scripts/device-steps.sh
+++ b/scripts/device-steps.sh
@@ -97,10 +97,15 @@ EOF
 cp $TMPDIR/watchdogled.conf $TMPDIR/watchdogall.conf
 for AGENT in $AGENTS; do
     echo "pidfile = /var/run/$AGENT.pid" >>$TMPDIR/watchdogall.conf
-    if [ "$AGENT" != "lisp-ztr" ]; then
-	echo "file = /var/run/$AGENT.touch" >>$TMPDIR/watchdogall.conf
-	echo "change = 300" >>$TMPDIR/watchdogall.conf
+    if [ "$AGENT" = "lisp-ztr" ]; then
+	continue
     fi
+    echo "file = /var/run/$AGENT.touch" >>$TMPDIR/watchdogall.conf
+    if [ "$AGENT" = "zedagent" ]; then
+	echo "file = /var/run/${AGENT}config.touch" >>$TMPDIR/watchdogall.conf
+	echo "file = /var/run/${AGENT}metrics.touch" >>$TMPDIR/watchdogall.conf
+    fi
+    echo "change = 300" >>$TMPDIR/watchdogall.conf
 done
 
 # In case watchdog is running we restart it with the base file

--- a/scripts/watchdog-report.sh
+++ b/scripts/watchdog-report.sh
@@ -22,6 +22,10 @@ if [ $# -ge 2 ]; then
     fi
 fi
 
+echo "Watchdog report at $DATE: $*" >>/persist/log/watchdog.log
+ps >>/persist/log/watchdog.log
+echo "Watchdog report done" >>/persist/log/watchdog.log
+
 CURPART=$(zboot curpart)
 echo "Watchdog report at $DATE: $*" >>/persist/"$CURPART"/reboot-reason
 sync

--- a/zboot/zboot.go
+++ b/zboot/zboot.go
@@ -97,17 +97,6 @@ func execWithTimeout(dolog bool, command string, args ...string) ([]byte, bool, 
 	return out, true, err
 }
 
-// tell watchdog we are fine
-func WatchdogOK() {
-	if !IsAvailable() {
-		return
-	}
-	_, err := execWithRetry(false, "zboot", "watchdog")
-	if err != nil {
-		log.Fatalf("zboot watchdog: err %v\n", err)
-	}
-}
-
 // Cache since it never changes on a running system
 // XXX lsblk seems to hang in kernel so avoid calling zboot curpart more
 // than once per process.


### PR DESCRIPTION
…of metrics should hang for 5 minutes or more.

Remove zboot watchdog since it is a no-op (and actually hung since the no-op uses lsblk etc to determine the rootdev etc).
Later we can remove the empty watchdog code from zboot script in zenbuild