### PR TITLE
Onboarding fix, etc

### DIFF
--- a/cmd/client/client.go
+++ b/cmd/client/client.go
@@ -627,7 +627,7 @@ func existingModel(model string) bool {
 		return false
 	}
 	DNCFilename := fmt.Sprintf("%s/%s.json", DNCDirname, model)
-	if _, err := os.Stat(DNCFilename); err == nil {
+	if _, err := os.Stat(DNCFilename); err != nil {
 		log.Debugln(err)
 		return false
 	}

--- a/conf/AssignableAdapters/Supermicro.Super Server.json
+++ b/conf/AssignableAdapters/Supermicro.Super Server.json
@@ -1,9 +1,0 @@
-{ "IoBundleList": [
-    { "Type": 1, "Name": "eth0", "Members": [ "eth0" ], "Lookup": true },
-    { "Type": 1, "Name": "eth1", "Members": [ "eth1" ], "Lookup": true },
-    { "Type": 2, "Name": "USB-C", "Members": [ "USB6" ], "PciLong": "0000:05:00.0", "Pcishort":"05:00.0" },
-    { "Type": 2, "Name": "USB-A", "Members": [ "USB0", "USB1", "USB2", "USB3", "USB4", "USB5" ], "PciLong": "0000:00:15.0", "PciShort": "00:15.0"},
-    { "Type": 3, "Name": "COM1", "Members": [ "COM1" ], "XenCfg": "irqs=[4]\nioports=['3f8-3ff']\n" },
-    { "Type": 3, "Name": "COM2", "Members": [ "COM2" ], "XenCfg": "irqs=[3]\nioports=['2f8-2ff']\n" },
-    { "Type": 3, "Name": "COM34", "Members": [ "COM3", "COM4" ], "XenCfg": "irqs=[7]\nioports=['3e8-3ff','2e8-2ff']\n" }
-] }

--- a/conf/DeviceNetworkConfig/Supermicro.Super Server.json
+++ b/conf/DeviceNetworkConfig/Supermicro.Super Server.json
@@ -1,4 +1,0 @@
-{
-    "Uplink":["eth0","wlan0","wwan0"],
-    "FreeUplinks":["eth0","wlan0"]
-}

--- a/dataplane/fib/mapfib.go
+++ b/dataplane/fib/mapfib.go
@@ -948,7 +948,7 @@ func publishLispMetrics(ctx *dptypes.DataplaneContext,
 	key := "global"
 	pub := ctx.PubLispMetrics
 	pub.Publish(key, *status)
-	log.Infof("publishLispMetrics: Done")
+	log.Debugf("publishLispMetrics: Done")
 }
 
 func unpublishLispMetrics(ctx *dptypes.DataplaneContext,

--- a/devicenetwork/devicenetwork.go
+++ b/devicenetwork/devicenetwork.go
@@ -72,6 +72,13 @@ func VerifyDeviceNetworkStatus(status types.DeviceNetworkStatus,
 	retryCount int) error {
 
 	log.Infof("VerifyDeviceNetworkStatus() %d\n", retryCount)
+	// Check if it is 1970 in which case we declare success since
+	// our certificates will not work until NTP has brought the time
+	// forward.
+	if time.Now().Year() == 1970 {
+		log.Infof("VerifyDeviceNetworkStatus skip due to 1970")
+		return nil
+	}
 
 	serverFileName := "/config/server"
 	server, err := ioutil.ReadFile(serverFileName)

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -280,7 +280,7 @@ func parseline(line string, table string, ipVer int) *AclCounters {
 		}
 		// Mark RateLimit flag
 		if items[i] == "-m" && items[i+1] == "limit" {
-			log.Infof("Marking RateLimit: true\n")
+			// log.Debugf("Marking RateLimit: true\n")
 			ac.Limit = true
 			i += 2
 			continue


### PR DESCRIPTION
Need to carry the onboarding fix to a 2.2.2 release since we can't get the model from the controller onto devices hence the devices do not report the proper set of AssignableAdapters.

Also, it is time to re-enable the hardware watchdog and have the Linux watchdog look for e.g., the dom0 qemu process going away.