### PR TITLE
 hostname-based ACLs broken - code uses NetworkObject and not NetworkInstance

### DIFF
--- a/cmd/zedmanager/updatestatus.go
+++ b/cmd/zedmanager/updatestatus.go
@@ -978,9 +978,12 @@ func doRemove(ctx *zedmanagerContext, uuidStr string,
 
 	changed := false
 	done := false
-	c := doInactivate(ctx, uuidStr, status)
+	c, done := doInactivate(ctx, uuidStr, status)
 	changed = changed || c
-
+	if !done {
+		log.Infof("doRemove waiting for inactivate for %s\n", uuidStr)
+		return changed, done
+	}
 	if !status.Activated {
 		c := doUnprepare(ctx, uuidStr, status)
 		changed = changed || c
@@ -997,10 +1000,11 @@ func doRemove(ctx *zedmanagerContext, uuidStr string,
 }
 
 func doInactivate(ctx *zedmanagerContext, uuidStr string,
-	status *types.AppInstanceStatus) bool {
+	status *types.AppInstanceStatus) (bool, bool) {
 
 	log.Infof("doInactivate for %s\n", uuidStr)
 	changed := false
+	done := false
 
 	// First halt the domain
 	unpublishDomainConfig(ctx, uuidStr)
@@ -1035,7 +1039,7 @@ func doInactivate(ctx *zedmanagerContext, uuidStr string,
 				changed = true
 			}
 		}
-		return changed
+		return changed, done
 	}
 
 	log.Infof("Done with DomainStatus removal for %s\n", uuidStr)
@@ -1079,13 +1083,14 @@ func doInactivate(ctx *zedmanagerContext, uuidStr string,
 			status.ErrorTime = time.Time{}
 			changed = true
 		}
-		return changed
+		return changed, done
 	}
 	log.Debugf("Done with AppNetworkStatus removal for %s\n", uuidStr)
+	done = true
 	status.Activated = false
 	status.ActivateInprogress = false
 	log.Infof("doInactivate done for %s\n", uuidStr)
-	return changed
+	return changed, true
 }
 
 func doUnprepare(ctx *zedmanagerContext, uuidStr string,

--- a/cmd/zedmanager/updatestatus.go
+++ b/cmd/zedmanager/updatestatus.go
@@ -1090,7 +1090,7 @@ func doInactivate(ctx *zedmanagerContext, uuidStr string,
 	status.Activated = false
 	status.ActivateInprogress = false
 	log.Infof("doInactivate done for %s\n", uuidStr)
-	return changed, true
+	return changed, done
 }
 
 func doUnprepare(ctx *zedmanagerContext, uuidStr string,

--- a/cmd/zedrouter/acl.go
+++ b/cmd/zedrouter/acl.go
@@ -41,12 +41,20 @@ func compileOverlayIpsets(ctx *zedrouterContext,
 
 	ipsets := []string{}
 	for _, olConfig := range ollist {
-		netconfig := lookupNetworkObjectConfig(ctx,
+		if !olConfig.UsesNetworkInstance {
+			log.Warnf("ACLs no longer support NetworkObject: %s",
+				olConfig.Network.String())
+			continue
+		}
+		netconfig := lookupNetworkInstanceConfig(ctx,
 			olConfig.Network.String())
 		if netconfig != nil {
 			// All ipsets from everybody on this network
 			ipsets = append(ipsets, compileNetworkIpsetsConfig(ctx,
 				netconfig)...)
+		} else {
+			log.Errorf("No NetworkInstanceConfig for %s",
+				olConfig.Network.String())
 		}
 	}
 	return ipsets
@@ -57,12 +65,20 @@ func compileUnderlayIpsets(ctx *zedrouterContext,
 
 	ipsets := []string{}
 	for _, ulConfig := range ullist {
-		netconfig := lookupNetworkObjectConfig(ctx,
+		if !ulConfig.UsesNetworkInstance {
+			log.Warnf("ACLs no longer support NetworkObject: %s",
+				ulConfig.Network.String())
+			continue
+		}
+		netconfig := lookupNetworkInstanceConfig(ctx,
 			ulConfig.Network.String())
 		if netconfig != nil {
 			// All ipsets from everybody on this network
 			ipsets = append(ipsets, compileNetworkIpsetsConfig(ctx,
 				netconfig)...)
+		} else {
+			log.Errorf("No NetworkInstanceConfig for %s",
+				ulConfig.Network.String())
 		}
 	}
 	return ipsets
@@ -80,7 +96,7 @@ func compileAppInstanceIpsets(ctx *zedrouterContext,
 
 // If skipKey is set ignore any AppNetworkConfig with that key
 func compileNetworkIpsetsStatus(ctx *zedrouterContext,
-	netconfig *types.NetworkObjectConfig, skipKey string) []string {
+	netconfig *types.NetworkInstanceConfig, skipKey string) []string {
 
 	ipsets := []string{}
 	if netconfig == nil {
@@ -121,7 +137,7 @@ func compileNetworkIpsetsStatus(ctx *zedrouterContext,
 }
 
 func compileNetworkIpsetsConfig(ctx *zedrouterContext,
-	netconfig *types.NetworkObjectConfig) []string {
+	netconfig *types.NetworkInstanceConfig) []string {
 
 	ipsets := []string{}
 	if netconfig == nil {
@@ -161,12 +177,20 @@ func compileOldOverlayIpsets(ctx *zedrouterContext,
 
 	ipsets := []string{}
 	for _, olStatus := range ollist {
-		netconfig := lookupNetworkObjectConfig(ctx,
+		if !olStatus.UsesNetworkInstance {
+			log.Warnf("ACLs no longer support NetworkObject: %s",
+				olStatus.Network.String())
+			continue
+		}
+		netconfig := lookupNetworkInstanceConfig(ctx,
 			olStatus.Network.String())
 		if netconfig != nil {
 			// All ipsets from everybody on this network
 			ipsets = append(ipsets, compileNetworkIpsetsStatus(ctx,
 				netconfig, skipKey)...)
+		} else {
+			log.Errorf("No NetworkInstanceConfig for %s",
+				olStatus.Network.String())
 		}
 	}
 	return ipsets
@@ -178,12 +202,20 @@ func compileOldUnderlayIpsets(ctx *zedrouterContext,
 
 	ipsets := []string{}
 	for _, ulStatus := range ullist {
-		netconfig := lookupNetworkObjectConfig(ctx,
+		if !ulStatus.UsesNetworkInstance {
+			log.Warnf("ACLs no longer support NetworkObject: %s",
+				ulStatus.Network.String())
+			continue
+		}
+		netconfig := lookupNetworkInstanceConfig(ctx,
 			ulStatus.Network.String())
 		if netconfig != nil {
 			// All ipsets from everybody on this network
 			ipsets = append(ipsets, compileNetworkIpsetsStatus(ctx,
 				netconfig, skipKey)...)
+		} else {
+			log.Errorf("No NetworkInstanceConfig for %s",
+				ulStatus.Network.String())
 		}
 	}
 	return ipsets

--- a/cmd/zedrouter/acl.go
+++ b/cmd/zedrouter/acl.go
@@ -738,6 +738,8 @@ func diffIpsets(newIpsets, oldIpsets []string) ([]string, []string, bool) {
 	if (len(newIpsets) != len(oldIpsets)) || (len(staleIpsets) != 0) {
 		restartDnsmasq = true
 	}
+	log.Infof("diffIpsets: restart %v, new %v, stale %v",
+		restartDnsmasq, newIpsets, staleIpsets)
 	return newIpsets, staleIpsets, restartDnsmasq
 }
 

--- a/cmd/zedrouter/dnsmasq.go
+++ b/cmd/zedrouter/dnsmasq.go
@@ -63,8 +63,8 @@ func createDnsmasqConfigletForNetworkInstance(
 	netconf *types.NetworkInstanceConfig, hostsDir string,
 	ipsets []string, Ipv4Eid bool) {
 
-	log.Debugf("createDnsmasqConfiglet: %s netconf %v\n",
-		bridgeName, netconf)
+	log.Infof("createDnsmasqConfiglet(%s, %s) netconf %v, ipsets %v\n",
+		bridgeName, bridgeIPAddr, netconf, ipsets)
 
 	cfgPathname := dnsmasqConfigPath(bridgeName)
 	// Delete if it exists
@@ -227,7 +227,7 @@ func createDnsmasqConfiglet(bridgeName string, bridgeIPAddr string,
 	netconf *types.NetworkObjectConfig, hostsDir string,
 	ipsets []string, Ipv4Eid bool) {
 
-	log.Debugf("createDnsmasqConfiglet: %s netconf %v\n",
+	log.Infof("createDnsmasqConfiglet: %s netconf %v\n",
 		bridgeName, netconf)
 
 	cfgPathname := dnsmasqConfigPath(bridgeName)
@@ -459,7 +459,7 @@ func removehostDnsmasq(bridgeName string, appMac string, appIPAddr string) {
 
 func deleteDnsmasqConfiglet(bridgeName string) {
 
-	log.Debugf("deleteDnsmasqConfiglet(%s)\n", bridgeName)
+	log.Infof("deleteDnsmasqConfiglet(%s)\n", bridgeName)
 	cfgPathname := dnsmasqConfigPath(bridgeName)
 	if _, err := os.Stat(cfgPathname); err == nil {
 		if err := os.Remove(cfgPathname); err != nil {
@@ -497,7 +497,7 @@ func RemoveDirContent(dir string) error {
 //    ${DMDIR}/dnsmasq -b -C /var/run/zedrouter/dnsmasq.${BRIDGENAME}.conf
 func startDnsmasq(bridgeName string) {
 
-	log.Debugf("startDnsmasq(%s)\n", bridgeName)
+	log.Infof("startDnsmasq(%s)\n", bridgeName)
 	cfgPathname := dnsmasqConfigPath(bridgeName)
 	name := "nohup"
 	//    XXX currently running as root with -d above
@@ -517,14 +517,14 @@ func startDnsmasq(bridgeName string) {
 	fmt.Fprintf(w, "%s Starting %s %v\n", ts, name, args)
 	cmd := exec.Command(name, args...)
 	cmd.Stderr = logf
-	log.Debugf("Calling command %s %v\n", name, args)
+	log.Infof("Calling command %s %v\n", name, args)
 	go cmd.Run()
 }
 
 //    pkill -u nobody -f dnsmasq.${BRIDGENAME}.conf
 func stopDnsmasq(bridgeName string, printOnError bool, delConfiglet bool) {
 
-	log.Debugf("stopDnsmasq(%s)\n", bridgeName)
+	log.Infof("stopDnsmasq(%s)\n", bridgeName)
 	cfgFilename := dnsmasqConfigFile(bridgeName)
 	// XXX currently running as root with -d above
 	pkillUserArgs("root", cfgFilename, printOnError)

--- a/cmd/zedrouter/networkinstance.go
+++ b/cmd/zedrouter/networkinstance.go
@@ -747,6 +747,9 @@ func getSwitchNetworkInstanceUsingPort(
 }
 
 func restartDnsmasq(status *types.NetworkInstanceStatus) {
+
+	log.Infof("restartDnsmasq(%s) ipsets %v\n",
+		status.BridgeName, status.BridgeIPSets)
 	bridgeName := status.BridgeName
 	stopDnsmasq(bridgeName, false, true)
 

--- a/cmd/zedrouter/zedrouter.go
+++ b/cmd/zedrouter/zedrouter.go
@@ -3464,7 +3464,19 @@ func pkillUserArgs(userName string, match string, printOnError bool) {
 		"-f",
 		match,
 	}
-	out, err := wrap.Command(cmd, args...).CombinedOutput()
+	var err error
+	var out []byte
+	for i := 0; i < 3; i++ {
+		out, err = wrap.Command(cmd, args...).CombinedOutput()
+		if err == nil {
+			break
+		}
+		if printOnError {
+			log.Warnf("Retrying failed command %v %v: %s output %s",
+				cmd, args, err, out)
+		}
+		time.Sleep(time.Second)
+	}
 	if err != nil && printOnError {
 		log.Errorf("Command %v %v failed: %s output %s\n",
 			cmd, args, err, out)

--- a/cmd/zedrouter/zedrouter.go
+++ b/cmd/zedrouter/zedrouter.go
@@ -1378,6 +1378,8 @@ func appNetworkDoActivateUnderlayNetworkWithNetworkInstance(
 	networkInstanceInfo.AddVif(vifName, appMac,
 		config.UUIDandVersion.UUID)
 	networkInstanceInfo.BridgeIPSets = newIpsets
+	log.Infof("set BridgeIPSets to %v for %s", newIpsets,
+		networkInstanceInfo.BridgeName)
 	publishNetworkInstanceStatus(ctx, netInstStatus)
 
 	maybeRemoveStaleIpsets(staleIpsets)
@@ -1502,6 +1504,8 @@ func appNetworkDoActivateUnderlayNetworkWithNetworkObject(
 	networkInstanceInfo.AddVif(vifName, appMac,
 		config.UUIDandVersion.UUID)
 	networkInstanceInfo.BridgeIPSets = newIpsets
+	log.Infof("set BridgeIPSets to %v for %s", newIpsets,
+		networkInstanceInfo.BridgeName)
 	publishNetworkObjectStatus(ctx, netstatus)
 
 	maybeRemoveStaleIpsets(staleIpsets)
@@ -1688,6 +1692,7 @@ func appNetworkDoActivateOverlayNetworkWithNetworkInstance(
 	netInstStatus.AddVif(vifName, appMac,
 		config.UUIDandVersion.UUID)
 	netInstStatus.BridgeIPSets = newIpsets
+	log.Infof("set BridgeIPSets to %v for %s", newIpsets, netInstStatus.Key())
 	publishNetworkInstanceStatus(ctx, netInstStatus)
 
 	maybeRemoveStaleIpsets(staleIpsets)
@@ -1852,6 +1857,7 @@ func appNetworkDoActivateOverlayNetworkWithNetworkObject(
 	netstatus.AddVif(vifName, appMac,
 		config.UUIDandVersion.UUID)
 	netstatus.BridgeIPSets = newIpsets
+	log.Infof("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
 	publishNetworkObjectStatus(ctx, netstatus)
 
 	maybeRemoveStaleIpsets(staleIpsets)
@@ -2606,6 +2612,7 @@ func doAppNetworkModifyUnderlayNetworkWithNetworkInstance(
 	}
 	netstatus.RemoveVif(ulStatus.Vif)
 	netstatus.BridgeIPSets = newIpsets
+	log.Infof("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
 	publishNetworkInstanceStatus(ctx, netstatus)
 
 	maybeRemoveStaleIpsets(staleIpsets)
@@ -2649,6 +2656,7 @@ func doAppNetworkModifyUnderlayNetworkWithNetworkObject(
 	}
 	netstatus.RemoveVif(ulStatus.Vif)
 	netstatus.BridgeIPSets = newIpsets
+	log.Infof("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
 	publishNetworkObjectStatus(ctx, netstatus)
 
 	maybeRemoveStaleIpsets(staleIpsets)
@@ -2730,6 +2738,7 @@ func doAppNetworkModifyOverlayNetworkWithNetworkInstance(
 	}
 	netstatus.NetworkInstanceInfo.RemoveVif(olStatus.Vif)
 	netstatus.BridgeIPSets = newIpsets
+	log.Infof("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
 	publishNetworkInstanceStatus(ctx, netstatus)
 
 	maybeRemoveStaleIpsets(staleIpsets)
@@ -2803,6 +2812,7 @@ func doAppNetworkModifyOverlayNetworkWithNetworkObject(
 	}
 	netstatus.NetworkInstanceInfo.RemoveVif(olStatus.Vif)
 	netstatus.BridgeIPSets = newIpsets
+	log.Infof("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
 	publishNetworkObjectStatus(ctx, netstatus)
 
 	maybeRemoveStaleIpsets(staleIpsets)
@@ -3022,6 +3032,7 @@ func appNetworkDoInactivateUnderlayNetworkWithNetworkInstance(
 		startDnsmasq(bridgeName)
 	}
 	netstatus.BridgeIPSets = newIpsets
+	log.Infof("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
 	maybeRemoveStaleIpsets(staleIpsets)
 }
 
@@ -3103,6 +3114,7 @@ func appNetworkDoInactivateUnderlayNetworkWithNetworkObject(
 		startDnsmasq(bridgeName)
 	}
 	netstatus.BridgeIPSets = newIpsets
+	log.Infof("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
 	maybeRemoveStaleIpsets(staleIpsets)
 }
 
@@ -3197,6 +3209,7 @@ func appNetworkDoInactivateOverlayNetworkWithNetworkInstance(
 		startDnsmasq(bridgeName)
 	}
 	netstatus.BridgeIPSets = newIpsets
+	log.Infof("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
 	maybeRemoveStaleIpsets(staleIpsets)
 
 	// Delete route towards app instance
@@ -3316,6 +3329,7 @@ func appNetworkDoInactivateOverlayNetworkWithNetworkObject(
 		startDnsmasq(bridgeName)
 	}
 	netstatus.BridgeIPSets = newIpsets
+	log.Infof("set BridgeIPSets to %v for %s", newIpsets, netstatus.Key())
 	maybeRemoveStaleIpsets(staleIpsets)
 
 	// If service does not exist overlays would not have been created

--- a/cmd/zedrouter/zedrouter.go
+++ b/cmd/zedrouter/zedrouter.go
@@ -1131,7 +1131,7 @@ var additionalInfoDevice *types.AdditionalInfoDevice
 
 func handleAppNetworkCreate(ctx *zedrouterContext, key string,
 	config types.AppNetworkConfig) {
-	log.Infof("handleCreateAppNetwork(%v) for %s\n",
+	log.Infof("handleAppAppNetworkCreate(%v) for %s\n",
 		config.UUIDandVersion, config.DisplayName)
 
 	// Pick a local number to identify the application instance
@@ -2698,7 +2698,7 @@ func doAppNetworkModifyOverlayNetworkWithNetworkInstance(
 		errStr := fmt.Sprintf("no network config for %s",
 			olConfig.Network.String())
 		err := errors.New(errStr)
-		addError(ctx, status, "lookupNetworkObjectConfig", err)
+		addError(ctx, status, "doAppNetworkModifyOverlayNetworkWithNetworkInstance overlay", err)
 		return
 	}
 	netstatus := lookupNetworkInstanceStatus(ctx,
@@ -2772,7 +2772,7 @@ func doAppNetworkModifyOverlayNetworkWithNetworkObject(
 		errStr := fmt.Sprintf("no network config for %s",
 			olConfig.Network.String())
 		err := errors.New(errStr)
-		addError(ctx, status, "lookupNetworkObjectConfig", err)
+		addError(ctx, status, "doAppNetworkModifyOverlay", err)
 		return
 	}
 	netstatus := lookupNetworkObjectStatus(ctx,


### PR DESCRIPTION
Will cherry-pick that fix into 2.2.X

Minor tweaks in the other commits.